### PR TITLE
Heatmap unit test

### DIFF
--- a/src/lib/PeriodicTable.svelte
+++ b/src/lib/PeriodicTable.svelte
@@ -29,7 +29,6 @@
   {#each elements as element}
     {@const value = element[heatmap]}
     {@const heatmap_color = value ? $color_scale?.(value) : `transparent`}
-    {@const bg_color = heatmap ? heatmap_color : null}
     {@const active =
       $active_category === element.category.replaceAll(` `, `-`) ||
       $active_element?.name === element.name}
@@ -45,7 +44,7 @@
         show_number={show_numbers}
         show_symbol={show_symbols}
         {value}
-        {bg_color}
+        bg_color={heatmap ? heatmap_color : null}
         {active}
         on:mouseenter={set_active_element(element)}
         on:mouseleave={set_active_element(null)}

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,6 +1,5 @@
 import { extent } from 'd3-array'
-import type { ScaleLinear } from 'd3-scale'
-import { scaleLinear } from 'd3-scale'
+import { scaleLinear, type ScaleLinear } from 'd3-scale'
 import { writable } from 'svelte/store'
 import elements from './element-data.yml'
 import type { ChemicalElement } from './types'

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,5 +1,4 @@
 import type { ChemicalElement } from '$lib/types'
-
 import { readFileSync } from 'fs'
 import yaml from 'js-yaml'
 

--- a/tests/unit/periodic-table.test.ts
+++ b/tests/unit/periodic-table.test.ts
@@ -1,5 +1,7 @@
 import elements from '$lib/element-data.yml'
+import { heatmap_labels } from '$lib/labels'
 import PeriodicTable from '$lib/PeriodicTable.svelte'
+import PropertySelect from '$lib/PropertySelect.svelte'
 import { beforeEach, describe, expect, test } from 'vitest'
 
 beforeEach(() => {
@@ -60,7 +62,7 @@ describe(`PeriodicTable`, () => {
     expect([...element_tile.classList]).not.toContain(`active`)
   })
 
-  test(`renders element photo when hovering element tile`, async () => {
+  test(`shows element photo when hovering element tile`, async () => {
     new PeriodicTable({ target: document.body })
 
     const rand_idx = Math.floor(Math.random() * elements.length)
@@ -77,5 +79,27 @@ describe(`PeriodicTable`, () => {
     element_tile?.dispatchEvent(new MouseEvent(`mouseleave`))
     await sleep()
     expect(document.querySelector(`img`)).toBeNull()
+  })
+
+  test(`hooking PeriodicTable up to PropertySelect and selecting heatmap sets element tile background`, async () => {
+    const ptable = new PeriodicTable({ target: document.body })
+    new PropertySelect({ target: document.body })
+
+    const li = doc_query(`ul.options > li`)
+    li.dispatchEvent(new MouseEvent(`mouseup`))
+    await sleep()
+
+    const selected = doc_query(`div.multiselect > ul.selected`)
+    const heatmap_label = `Atomic Mass (u)`
+    expect(selected.textContent?.trim()).toBe(heatmap_label)
+    const heatmap_key = heatmap_labels[heatmap_label]
+
+    expect(heatmap_key).toBe(`atomic_mass`)
+    ptable.$set({ heatmap: heatmap_key })
+    await sleep()
+
+    const element_tile = doc_query(`div.element-tile`)
+
+    expect(element_tile.style.backgroundColor).toBe(`rgb(0, 0, 255)`)
   })
 })


### PR DESCRIPTION
Test name: `'hooking PeriodicTable up to PropertySelect and selecting heatmap sets element tile background'`.

Partially to check if [notes on downstream testing of `svelte-multiselect`](https://github.com/janosh/svelte-multiselect/blob/ba509a1e2dbf39d070ce3dbe59df3dfd32e171f4/readme.md#downstream-testing) are still relevant. Appears not.

